### PR TITLE
fix: update footer background color to bg-base-100

### DIFF
--- a/src/components/TheFooter.vue
+++ b/src/components/TheFooter.vue
@@ -1,5 +1,5 @@
 <template>
-    <footer class="footer footer-horizontal footer-center bg-base-200 text-base-content rounded p-10">
+    <footer class="footer footer-horizontal footer-center bg-base-100 text-base-content rounded p-10">
         <nav class="grid grid-flow-col gap-4">
             <a v-for="link in links" :key="link.name" class="link link-hover" :href="link.path">{{ link.name }}</a>
         </nav>

--- a/src/style.css
+++ b/src/style.css
@@ -1,4 +1,4 @@
 @import "tailwindcss";
 @plugin "daisyui" {
     themes: night --default;
-  }
+}


### PR DESCRIPTION
Change the footer background color from bg-base-200 to bg-base-100
to improve visual consistency with the overall site design and ensure
better contrast with the text content.