### PR TITLE
fix(ui): improve dropdown close button styling on world map

### DIFF
--- a/src/pages/PageWorldMap.vue
+++ b/src/pages/PageWorldMap.vue
@@ -12,14 +12,13 @@
                                 class="bg-white/60 w-8 h-8 rounded-full grid justify-center items-center cursor-pointer group-focus-within:border-2 group-focus-within:border-neutral">
                                 <div class="w-5 h-5 bg-white/70 rounded-full"></div>
                             </div>
-
                             <div tabindex="0" role="button" class="absolute whitespace-nowrap cursor-pointer [inset-inline-end:_calc(1/2_*_100%)] translate-x-[50%] bg-base-100/70 group-focus-within:bg-base-100/90 px-1 mt-1 rounded-xs">{{ point.name}}</div>
                             <div tabindex="0" class="dropdown-content card card-sm bg-base-300 z-1 w-64 shadow-lg mt-8">
                                 <div class="card-body">
                                     <p class="font-bold">{{ point.name }}</p>
                                     <p>This is a card. You can use any element as a dropdown.</p>
                                 </div>
-                                <button onclick="document.activeElement.blur()" class="cursor-pointer">close</button>
+                                <button class="btn btn-neutral btn-sm btn-circle btn-ghost absolute right-2 top-2" onclick="document.activeElement.blur()">✕</button>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
Update the close button in the dropdown card to use consistent
button styles and positioning. Replace the plain button with a
styled, circular, ghost button positioned at the top-right corner
to enhance usability and visual clarity. This change improves the
user experience by making the close action more accessible and
visually distinct.