### PR TITLE
feat: replace anchor tags with RouterLink in header navigation

### DIFF
--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -19,7 +19,7 @@
             </div>
             <div class="navbar-center hidden lg:flex">
                 <ul class="menu menu-horizontal px-1">
-                    <li v-for="link in links" :key="link.name"><a :href="link.path">{{ link.name }}</a></li>
+                    <li v-for="link in links" :key="link.name"><RouterLink :to="link.path" activeClass="underline">{{ link.name }}</RouterLink></li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
Update TheHeader component to use Vue Router's RouterLink instead
of standard anchor tags for navigation links. This change enables
client-side routing with active link styling, improving navigation
performance and user experience.