### PR TITLE
style: scope styles in PageWorldMap.vue to avoid leaks

### DIFF
--- a/src/pages/PageWorldMap.vue
+++ b/src/pages/PageWorldMap.vue
@@ -47,7 +47,7 @@ const points = [
 ]
 </script>
 
-<style>
+<style scoped>
 .pulstrigger {
     animation: pulse 3s infinite;
 }


### PR DESCRIPTION
Add scoped attribute to the style block in PageWorldMap.vue to
limit CSS rules to this component only. This prevents style
leakage and potential conflicts with components.