### PR TITLE
feat(privacy): add detailed German privacy policy page

### DIFF
--- a/src/pages/PagePrivacyPolicy.vue
+++ b/src/pages/PagePrivacyPolicy.vue
@@ -1,6 +1,154 @@
 <template>
     <LayoutBasic :breadcrumbs="breadcrumbs">
-        Page Privacy Policy
+        <div class="m-auto grid h-full max-w-2xl p-8 text-left">
+            <div class="flex flex-col gap-6">
+                <h1 class="break-all text-2xl font-bold md:text-4xl">
+                    Datenschutzerklärung
+                </h1>
+                <div class="grid gap-4">
+                    <div class="grid gap-1">
+                        <h2 class="text-lg font-bold">1. Allgemeine Hinweise</h2>
+                        <p>
+                            Der Schutz Ihrer persönlichen Daten ist uns ein wichtiges
+                            Anliegen. Wir behandeln Ihre personenbezogenen Daten vertraulich
+                            und entsprechend den gesetzlichen Datenschutzvorschriften der
+                            Schweiz (DSG) sowie dieser Datenschutzerklärung.
+                        </p>
+                    </div>
+
+                    <div>
+                        <h2 class="text-lg font-bold">2. Verantwortliche Stelle</h2>
+                        <p>
+                            Die verantwortliche Stelle für die Datenverarbeitung auf dieser
+                            Website ist: <br />
+                            Voxel Core Lab GmbH<br />
+                            Fährstrasse 49<br />
+                            3004 Bern<br />
+                            E-Mail: voxelcorelab@gmail.com
+                        </p>
+                    </div>
+
+                    <div class="grid gap-1">
+                        <h2 class="text-lg font-bold">
+                            3. Erfassung und Verarbeitung personenbezogener Daten
+                        </h2>
+                        <p>
+                            Personenbezogene Daten sind alle Informationen, die sich auf eine
+                            identifizierte oder identifizierbare Person beziehen. Wir erheben
+                            und verarbeiten Ihre personenbezogenen Daten nur, wenn dies
+                            gesetzlich erlaubt ist oder Sie in die Datenerhebung einwilligen.
+                        </p>
+                    </div>
+
+                    <div class="grid gap-1">
+                        <h2 class="text-lg font-bold">
+                            4. Datenerfassung auf unserer Website
+                        </h2>
+                        <p>
+                            Unsere Website erfasst Daten automatisch durch den Besuch der
+                            Website. Dies sind insbesondere technische Informationen (z. B.
+                            Browsertyp, Betriebssystem, IP-Adresse). Diese Daten sind anonym
+                            und werden primär zur Analyse und zur Verbesserung unserer Website
+                            verwendet.
+                        </p>
+                    </div>
+
+                    <div class="grid gap-1">
+                        <h2 class="text-lg font-bold">
+                            5. Newsletter
+                        </h2>
+                        <p>
+                            Wenn Sie sich auf unserer Website für den Newsletter anmelden, erheben wir Ihre
+                            E-Mail-Adresse. Diese Angabe ist erforderlich, um Ihnen den Newsletter zusenden zu können.
+                            Die Verarbeitung dieser Daten erfolgt ausschliesslich auf Grundlage Ihrer Einwilligung (Art.
+                            6 Abs. 6 DSG).
+                        </p>
+                        <p>
+                            Ihre E-Mail-Adresse wird ausschliesslich für den Versand des Newsletters verwendet und nicht
+                            an Dritte weitergegeben. Sie können Ihre Einwilligung jederzeit widerrufen, indem Sie sich
+                            vom Newsletter abmelden. Den Abmeldelink finden Sie in jeder Newsletter-E-Mail. Nach
+                            erfolgter Abmeldung wird Ihre E-Mail-Adresse umgehend aus dem Verteiler gelöscht.
+                        </p>
+                        <p>
+                            Die Datenverarbeitung erfolgt durch uns selbst oder durch einen datenschutzkonformen
+                            Dienstleister mit Sitz in der Schweiz oder im EWR-Raum.
+                        </p>
+                    </div>
+
+                    <div class="grid gap-1">
+                        <h2 class="text-lg font-bold">6. Verwendung von Umami Analytics</h2>
+                        <p>
+                            Diese Website verwendet Umami Analytics, ein
+                            datenschutzfreundliches Analysetool. Umami verwendet keine Cookies
+                            und sammelt keine persönlichen Daten der Besucher. Stattdessen
+                            wird nur aggregierte, anonymisierte Nutzungsstatistik erfasst, um
+                            das Verhalten der Benutzer auf unserer Website zu analysieren. Die
+                            Daten werden ausschliesslich auf unseren eigenen Servern in der
+                            Schweiz gespeichert und verarbeitet.
+                        </p>
+                    </div>
+
+                    <div class="grid gap-1">
+                        <h2 class="text-lg font-bold">7. Zweck der Datenverarbeitung</h2>
+                        <p>Wir verwenden die erhobenen Daten, um:</p>
+                        <ul class="list-inside list-disc">
+                            <li>den reibungslosen Betrieb der Website sicherzustellen,</li>
+                            <li>
+                                die Nutzerfreundlichkeit und Inhalte unserer Website zu
+                                verbessern, und
+                            </li>
+                            <li>
+                                statistische Auswertungen zur Verbesserung unserer Angebote zu
+                                erstellen.
+                            </li>
+                        </ul>
+                    </div>
+
+                    <div class="grid gap-1">
+                        <h2 class="text-lg font-bold">8. Weitergabe von Daten</h2>
+                        <p>
+                            Eine Weitergabe Ihrer Daten an Dritte erfolgt nur, wenn dies zur
+                            Erfüllung vertraglicher Pflichten notwendig ist, eine gesetzliche
+                            Verpflichtung besteht oder Sie in die Weitergabe eingewilligt
+                            haben.
+                        </p>
+                    </div>
+
+                    <div class="grid gap-1">
+                        <h2 class="text-lg font-bold">9. Rechte der betroffenen Person</h2>
+                        <p>
+                            Sie haben jederzeit das Recht, Auskunft über Ihre bei uns
+                            gespeicherten personenbezogenen Daten zu erhalten, diese
+                            berichtigen, sperren oder löschen zu lassen. Bei Fragen zum Thema
+                            Datenschutz können Sie uns unter der oben genannten Adresse
+                            kontaktieren.
+                        </p>
+                    </div>
+
+                    <div class="grid gap-1">
+                        <h2 class="text-lg font-bold">
+                            10. Änderungen dieser Datenschutzerklärung
+                        </h2>
+                        <p>
+                            Wir behalten uns das Recht vor, diese Datenschutzerklärung
+                            jederzeit anzupassen, damit sie stets den aktuellen rechtlichen
+                            Anforderungen entspricht oder um Änderungen unserer Leistungen in
+                            der Datenschutzerklärung umzusetzen.
+                        </p>
+                    </div>
+
+                    <div class="grid gap-1">
+                        <h2 class="text-lg font-bold">11. Schlussbestimmungen</h2>
+                        <p>
+                            Auf diese Vereinbarung ist ausschliesslich schweizerisches Recht
+                            anwendbar. Gerichtsstand ist Bern.
+                        </p>
+                    </div>
+
+                    <p>Stand: April 2025</p>
+                </div>
+            </div>
+        </div>
     </LayoutBasic>
 </template>
 <script setup lang="ts">


### PR DESCRIPTION
Expand the Privacy Policy page with comprehensive sections in German,
covering general data protection, responsible entity, data collection,
 data processing, handling, and use Umami Analytics.
This update ensures legal compliance with Swiss data protection laws (DSG)
and improves transparency for users regarding their personal data usage.