### PR TITLE
fix(footer): add top padding to improve footer spacing

### DIFF
--- a/src/components/TheFooter.vue
+++ b/src/components/TheFooter.vue
@@ -1,5 +1,5 @@
 <template>
-    <footer class="footer footer-horizontal footer-center bg-base-100 text-base-content rounded p-10">
+    <footer class="footer footer-horizontal footer-center bg-base-100 text-base-content rounded p-10 pt-32">
         <nav class="grid grid-flow-col gap-4">
             <a v-for="link in links" :key="link.name" class="link link-hover" :href="link.path">{{ link.name }}</a>
         </nav>


### PR DESCRIPTION
Increase the top padding of the footer to 8rem (pt-32) to create
better visual separation from the content above. This change
enhances the overall layout and readability on the page.