### PR TITLE
style(PageHome): add shadow to teaser text box

### DIFF
--- a/src/pages/PageHome.vue
+++ b/src/pages/PageHome.vue
@@ -5,7 +5,7 @@
       <img alt="" src="../assets/world-map-teaser.jpg" class="w-full max-h-[calc(100vh/2)] object-cover mx-auto" />
       <div class="absolute z-10 w-full bottom-0">
         <div class="max-w-6xl mx-auto py-4">
-          <div class="bg-neutral p-4 rounded-box inline-flex flex-col gap-4 w-96">
+          <div class="bg-neutral p-4 rounded-box inline-flex flex-col gap-4 w-96 shadow-2xl shadow-amber-800/30">
             <div class="text-lg">
               <p class="text-4xl font-bold">Entdecke jetzt die Spielwelt!</p>
               <p>Jede Region flüstert Geschichten – bist du bereit, ihnen zu lauschen?</p>


### PR DESCRIPTION
Add a strong amber shadow to the teaser text box on the home page to
improve visual depth and make the call-to-action stand out more clearly.
This enhances the overall aesthetic and draws user attention to the
invitation to explore the game world.