### PR TITLE
feat(page-home): enhance hero section with updated layout and CTA

### DIFF
--- a/src/pages/PageHome.vue
+++ b/src/pages/PageHome.vue
@@ -5,13 +5,19 @@
       <img alt="" src="../assets/world-map-teaser.jpg" class="w-full h-[calc(100vh-6rem)] object-cover mx-auto" />
       <img alt="Spieletitel: Shadow Infection" src="../assets/shadowInfectionHeading.png" class="absolute top-4 left-1/2 -translate-x-1/2 max-h-[calc(100vh/3)] object-cover mx-auto z-10 drop-shadow-xl/50" />
       <div class="absolute z-10 w-full bottom-0">
-        <div class="max-w-6xl mx-auto pt-4 px-4 pb-24">
-          <div class="bg-neutral p-4 rounded-box border border-secondary/50 inline-flex flex-col gap-4 w-96 shadow-2xl shadow-amber-800/30">
+        <div class="max-w-6xl mx-auto pt-4 px-4 pb-50 grid justify-items-center">
+          <div class="p-4 inline-flex flex-col gap-4 drop-shadow-xl/50">
             <div class="text-lg">
-              <p class="text-2xl font-bold">Entdecke jetzt die Spielwelt!</p>
-              <p>Jede Region flüstert Geschichten – bist du bereit, ihnen zu lauschen?</p>
+              <p class="text-4xl font-bold">Entdecke jetzt die Spielwelt!</p>
             </div>
-            <a href="/world-map" class="btn btn-secondary text-lg">Zur Weltkarte</a>
+            <div class="self-center">
+                <a href="/world-map" class="btn btn-secondary text-lg inline-flex items-center gap-2">
+                Zur Weltkarte
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
+                </svg>
+                </a>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Increase heading size for better emphasis and replace text with a 
clearer call to action. Change layout from a bordered box to a centered 
grid with drop shadow for a cleaner, modern look. Add an inline SVG 
arrow icon to the "Zur Weltkarte" button to improve visual guidance 
and encourage user interaction.