### PR TITLE
fix(ui): use svh unit for header image max height

### DIFF
--- a/src/pages/PageHome.vue
+++ b/src/pages/PageHome.vue
@@ -4,7 +4,7 @@
     <div class="world-map relative">
       <img alt="" src="../assets/world-map-teaser.jpg" class="w-full h-[calc(100vh-6rem)] object-cover mx-auto" />
       <img alt="Spieletitel: Shadow Infection" src="../assets/header_site.webp"
-        class="absolute top-4 left-1/2 -translate-x-1/2 max-h-[calc(100vh/3)] object-cover mx-auto z-10 drop-shadow-xl/50" />
+        class="absolute top-4 left-1/2 -translate-x-1/2 max-h-[calc(100svh/3)] object-cover mx-auto z-10 drop-shadow-xl/50" />
       <div class="absolute z-10 w-full bottom-0">
         <div class="max-w-6xl mx-auto pt-4 px-4 pb-50 grid justify-items-center">
           <div class="p-4 inline-flex flex-col gap-4 drop-shadow-xl/50">


### PR DESCRIPTION
Update the max-height of the header image in PageHome.vue from
calc(100vh/3) to calc(100svh/3) to improve viewport height handling
on mobile browsers with dynamic toolbars. This change ensures the
image scales correctly across different devices and screen sizes.