### PR TITLE
fix: replace vh with svh units for better viewport sizing

### DIFF
--- a/src/pages/PageHome.vue
+++ b/src/pages/PageHome.vue
@@ -2,7 +2,7 @@
   <LayoutBasic>
     <!-- <h1 class="text-8xl font-bold max-w-6xl mx-auto py-8 px-4">Shadow Infection</h1> -->
     <div class="world-map relative">
-      <img alt="" src="../assets/world-map-teaser.jpg" class="w-full h-[calc(100vh-6rem)] object-cover mx-auto" />
+      <img alt="" src="../assets/world-map-teaser.jpg" class="w-full h-[calc(100svh-6rem)] object-cover mx-auto" />
       <img alt="Spieletitel: Shadow Infection" src="../assets/header_site.webp"
         class="absolute top-4 left-1/2 -translate-x-1/2 max-h-[calc(100svh/3)] object-cover mx-auto z-10 drop-shadow-xl/50" />
       <div class="absolute z-10 w-full bottom-0">


### PR DESCRIPTION
Update the height and max-height CSS properties in PageHome.vue
to use the small viewport height (svh) unit instead of vh.
This change improves layout consistency on mobile browsers
where vh units can be affected by browser UI elements.