### PR TITLE
fix(ui): add top padding to main content container

### DIFF
--- a/src/pages/PageHome.vue
+++ b/src/pages/PageHome.vue
@@ -55,7 +55,7 @@
         </div>
       </div>
     </div>
-    <div class="bg-base-100">
+    <div class="bg-base-100 pt-16">
       <div class="max-w-6xl mx-auto relative">
         <div
           class="absolute top-0 bottom-0 left-0 w-64 bg-gradient-to-r from-base-100 to-transparent pointer-events-none z-10">


### PR DESCRIPTION
Add a top padding of 16 to the main content container on the home page.
This adjustment improves spacing and prevents content from being too close
to the top edge, enhancing the overall layout and visual balance.