### PR TITLE
feat: rename gameplay route to skills and add FAQ content

### DIFF
--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -31,7 +31,7 @@ const links = [
     { name: 'Home', path: '/' },
     { name: 'Weltkarte', path: '/world-map' },
     { name: 'Spielverlauf', path: '/game-process' },
-    { name: 'Gameplay', path: '/gameplay' },
+    { name: 'Fähigkeiten', path: '/skills' },
     { name: 'FAQ', path: '/faq' }
 ]
 </script>

--- a/src/pages/PageFaq.vue
+++ b/src/pages/PageFaq.vue
@@ -1,6 +1,17 @@
 <template>
     <LayoutBasic :breadcrumbs="breadcrumbs">
-        Page Faq
+        <div class="max-w-2xl mx-auto px-8 py-8">
+            <h1 class="text-5xl font-bold font-nebulous-regular">FAQ</h1>
+            <p class="text-sm">Hier findest du die häufigsten Fragen und Antworten zu unserem Spiel.</p>
+            <div class="mt-4">
+                <div v-for="(faq, index) in faqs" :key="index" tabindex="0" class="collapse collapse-arrow bg-base-100 border-base-300 border">
+                    <div class="collapse-title font-semibold">{{ faq.question }}</div>
+                    <div class="collapse-content text-sm">
+                        {{ faq.answer }}
+                    </div>
+                </div>
+            </div>
+        </div>
     </LayoutBasic>
 </template>
 <script setup lang="ts">
@@ -10,6 +21,33 @@ const breadcrumbs = [
     {
         text: 'FAQ',
         href: '/faq'
+    }
+]
+
+const faqs: { question: string, answer: string }[] = [
+    {
+        question: 'Weleches Betriebssystem wird benötigt?',
+        answer: 'Das Spiel läuft auf Windows 11'
+    },
+    {
+        question: 'Was für ein Genre ist das Spiel?',
+        answer: 'Das Spiel ist ein Co-op Online Arena Survival Game.'
+    },
+    {
+        question: 'Wie lange dauert eine Runde?',
+        answer: 'Eine Runde dauert etwa 30 Minuten'
+    },
+    {
+        question: 'Wie viele Spieler können mitspielen?',
+        answer: 'Das Spiel ist für 1-5 Spieler ausgelegt.'
+    },
+    {
+        question: 'Wie viele Karten gibt es?',
+        answer: 'Es gibt 3 verschiedene Karten'
+    },
+    {
+        question: 'Welche Steuerung wird in Shadow Infection verwendet?',
+        answer: 'Das Spiel wird mit Maus und Tastatur gespielt.'
     }
 ]
 </script>

--- a/src/pages/PageSkills.vue
+++ b/src/pages/PageSkills.vue
@@ -1,0 +1,15 @@
+<template>
+    <LayoutBasic :breadcrumbs="breadcrumbs">
+        Page Fähigkeiten
+    </LayoutBasic>
+</template>
+<script setup lang="ts">
+import LayoutBasic from '../layouts/LayoutBasic.vue'
+
+const breadcrumbs = [
+    {
+        text: 'Fähigkeiten',
+        href: '/skills'
+    }
+]
+</script>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -8,7 +8,7 @@ const router = createRouter({
         { path: '/', component: PageHome },
         { path: '/world-map', component: () => import('../pages/PageWorldMap.vue') },
         { path: '/game-process', component: () => import('../pages/PageGameProcess.vue') },
-        { path: '/gameplay', component: () => import('../pages/PageGameplay.vue') },
+        { path: '/skills', component: () => import('../pages/PageSkills.vue') },
         { path: '/faq', component: () => import('../pages/PageFaq.vue') },
         { path: '/imprint', component: () => import('../pages/PageImprint.vue') },
         { path: '/contact', component: () => import('../pages/PageContact.vue') },


### PR DESCRIPTION
Rename the '/gameplay' route to '/skills' and update the header link 
to reflect this change. Add a new FAQ page with a list of common 
questions and answers to improve user support and provide essential 
game information.