### PR TITLE
feat(navigation): add responsive sidebar with navigation links

### DIFF
--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -2,36 +2,29 @@
     <header class="bg-base-100 shadow-sm">
         <div class="navbar bg-base-100 max-w-7xl mx-auto">
             <div class="navbar-start w-auto">
-                <div class="dropdown">
-                    <div tabindex="0" role="button" class="btn btn-ghost lg:hidden">
-                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24"
-                            stroke="currentColor">
+                <div class="flex-none lg:hidden">
+                    <label for="my-drawer" aria-label="open sidebar" class="btn btn-square btn-ghost">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                            class="inline-block h-6 w-6 stroke-current">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                d="M4 6h16M4 12h8m-8 6h16" />
+                                d="M4 6h16M4 12h16M4 18h16"></path>
                         </svg>
-                    </div>
-                    <ul tabindex="0"
-                        class="menu menu-lg dropdown-content bg-base-100 rounded-box z-1 mt-3 w-52 p-2 shadow">
-                        <li v-for="link in links" :key="link.name"><a :href="link.path">{{ link.name }}</a></li>
-                    </ul>
+                    </label>
                 </div>
                 <a class="btn btn-ghost text-xl " href="/"><img class="h-8 w-8" alt="" src="../assets/logo.png"></a>
             </div>
             <div class="navbar-center hidden lg:flex">
                 <ul class="menu menu-horizontal px-1">
-                    <li v-for="link in links" :key="link.name"><RouterLink :to="link.path" activeClass="underline">{{ link.name }}</RouterLink></li>
+                    <li v-for="link in links" :key="link.name">
+                        <RouterLink :to="link.path" activeClass="underline">{{ link.name }}</RouterLink>
+                    </li>
                 </ul>
             </div>
         </div>
     </header>
 </template>
 <script setup lang="ts">
+import { useNavigationLinks } from '../composables/useNavigationLinks';
 
-const links = [
-    { name: 'Home', path: '/' },
-    { name: 'Weltkarte', path: '/world-map' },
-    { name: 'Spielverlauf', path: '/game-process' },
-    { name: 'Fertigkeiten', path: '/skills' },
-    { name: 'FAQ', path: '/faq' }
-]
+const { links } = useNavigationLinks();
 </script>

--- a/src/composables/useNavigationLinks.ts
+++ b/src/composables/useNavigationLinks.ts
@@ -1,0 +1,12 @@
+export function useNavigationLinks() {
+    const links = [
+        { name: 'Home', path: '/' },
+        { name: 'Weltkarte', path: '/world-map' },
+        { name: 'Spielverlauf', path: '/game-process' },
+        { name: 'Fertigkeiten', path: '/skills' },
+        { name: 'FAQ', path: '/faq' }
+    ]
+    return {
+        links
+    }
+}

--- a/src/layouts/LayoutBasic.vue
+++ b/src/layouts/LayoutBasic.vue
@@ -1,17 +1,40 @@
 <template>
-    <div class="grid min-h-svh grid-rows-[auto_1fr_auto]">
-        <TheHeader />
-        <main>
-            <TheBreadcrumbs v-if="breadcrumbs" :items="breadcrumbs" />
-            <slot />
-        </main>
-        <TheFooter />
+    <div class="drawer">
+        <input id="my-drawer" type="checkbox" class="drawer-toggle" />
+        <div class="drawer-content grid min-h-svh grid-rows-[auto_1fr_auto]">
+            <TheHeader />
+            <main>
+                <TheBreadcrumbs v-if="breadcrumbs" :items="breadcrumbs" />
+                <slot />
+            </main>
+            <TheFooter />
+        </div>
+        <div class="drawer-side z-50">
+            <label for="my-drawer" aria-label="close sidebar" class="drawer-overlay"></label>
+            <ul class="menu bg-base-200 min-h-full w-80 p-2 pt-3">
+                <!-- Sidebar content here -->
+                <li class="flex flex-row">
+                    <label for="my-drawer" aria-label="close sidebar" class="btn btn-square btn-ghost">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                            class="inline-block h-6 w-6 stroke-current">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                d="M4 6h16M4 12h16M4 18h16"></path>
+                        </svg>
+                    </label>
+                    <a class="btn btn-ghost text-xl" href="/"><img class="h-8 w-8" alt="" src="../assets/logo.png"></a>
+                </li>
+                <li v-for="link in links" :key="link.name">
+                    <RouterLink :to="link.path" activeClass="underline">{{ link.name }}</RouterLink>
+                </li>
+            </ul>
+        </div>
     </div>
 </template>
 <script setup lang="ts">
 import TheHeader from '../components/TheHeader.vue'
 import TheFooter from '../components/TheFooter.vue'
 import TheBreadcrumbs from '../components/TheBreadcrumbs.vue';
+import { useNavigationLinks } from '../composables/useNavigationLinks';
 
 defineProps<{
     breadcrumbs?: {
@@ -19,4 +42,6 @@ defineProps<{
         href: string
     }[]
 }>()
+
+const { links } = useNavigationLinks();
 </script>


### PR DESCRIPTION
Introduce a composable to centralize navigation links and update the
layout to include a drawer sidebar for improved navigation on smaller
screens. Replace the previous dropdown menu in the header with a
hamburger button that toggles the sidebar. This enhances usability and
provides a consistent navigation experience across devices.