### PR TITLE
fix(header): adjust navbar visibility breakpoints for responsiveness

### DIFF
--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -2,7 +2,7 @@
     <header class="bg-base-100 shadow-sm">
         <div class="navbar bg-base-100 max-w-7xl mx-auto">
             <div class="navbar-start w-auto">
-                <div class="flex-none lg:hidden">
+                <div class="flex-none md:hidden">
                     <label for="my-drawer" aria-label="open sidebar" class="btn btn-square btn-ghost">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
                             class="inline-block h-6 w-6 stroke-current">
@@ -13,7 +13,7 @@
                 </div>
                 <a class="btn btn-ghost text-xl " href="/"><img class="h-8 w-8" alt="" src="../assets/logo.png"></a>
             </div>
-            <div class="navbar-center hidden lg:flex">
+            <div class="navbar-center hidden md:flex">
                 <ul class="menu menu-horizontal px-1">
                     <li v-for="link in links" :key="link.name">
                         <RouterLink :to="link.path" activeClass="underline">{{ link.name }}</RouterLink>


### PR DESCRIPTION
Change navbar-center visibility from lg:flex to md:flex to show menu
on medium screens. Update drawer toggle button visibility from lg:hidden
to md:hidden to better support sidebar access on smaller devices. These
changes improve the header's responsiveness and usability across screen
sizes.