### PR TITLE
feat(layout): move sidebar drawer to App.vue and update breadcrumbs

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,40 @@
 <template>
-  <RouterView :key="$route.path" />
+      <div class="drawer">
+        <input id="my-drawer" type="checkbox" class="drawer-toggle" v-model="isDrawerOpen" />
+        <div class="drawer-content">
+          <RouterView :key="$route.path" />
+        </div>
+        <div class="drawer-side z-50">
+            <label for="my-drawer" aria-label="close sidebar" class="drawer-overlay"></label>
+            <ul class="menu bg-base-200 min-h-full w-80 p-0">
+                <!-- Sidebar content here -->
+                <li class="flex flex-row px-2 py-3">
+                    <label for="my-drawer" aria-label="close sidebar" class="btn btn-square btn-ghost">
+                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
+                            class="inline-block h-6 w-6 stroke-current">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                d="M4 6h16M4 12h16M4 18h16"></path>
+                        </svg>
+                    </label>
+                    <a class="btn btn-ghost text-xl" href="/"><img class="h-8 w-8" alt="" src="./assets/logo.png"></a>
+                </li>
+                <hr class="text-secondary/50 pb-3" />
+                <li v-for="link in links" :key="link.name">
+                    <RouterLink class="py-2 text-lg mx-2" :to="link.path" activeClass="bg-secondary/25" @click="() => closeDrawer()">{{ link.name }}</RouterLink>
+                </li>
+            </ul>
+        </div>
+    </div>
 </template>
 <script setup lang="ts">
+import { ref } from 'vue';
+import { useNavigationLinks } from './composables/useNavigationLinks';
+
+const { links } = useNavigationLinks();
+
+const isDrawerOpen = ref(false);
+
+const closeDrawer = () => {
+    isDrawerOpen.value = false;
+};
 </script>

--- a/src/components/TheBreadcrumbs.vue
+++ b/src/components/TheBreadcrumbs.vue
@@ -2,14 +2,14 @@
     <div class="breadcrumbs text-sm max-w-7xl mx-auto px-8 py-4">
         <ul>
             <li>
-                <a href="/">
+                <RouterLink to="/">
                     <IconHome class="h-4 w-4" />
-                </a>
+                </RouterLink>
             </li>
             <li v-for="(item, index) in items" :key="index">
-                <a :href="item.href">
+                <RouterLink :to="item.href">
                     {{ item.text }}
-                </a>
+                </RouterLink>
             </li>
         </ul>
     </div>

--- a/src/layouts/LayoutBasic.vue
+++ b/src/layouts/LayoutBasic.vue
@@ -1,41 +1,17 @@
 <template>
-    <div class="drawer">
-        <input id="my-drawer" type="checkbox" class="drawer-toggle" />
-        <div class="drawer-content grid min-h-svh grid-rows-[auto_1fr_auto]">
-            <TheHeader />
-            <main>
-                <TheBreadcrumbs v-if="breadcrumbs" :items="breadcrumbs" />
-                <slot />
-            </main>
-            <TheFooter />
-        </div>
-        <div class="drawer-side z-50">
-            <label for="my-drawer" aria-label="close sidebar" class="drawer-overlay"></label>
-            <ul class="menu bg-base-200 min-h-full w-80 p-2 pt-3">
-                <!-- Sidebar content here -->
-                <li class="flex flex-row pb-3">
-                    <label for="my-drawer" aria-label="close sidebar" class="btn btn-square btn-ghost">
-                        <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
-                            class="inline-block h-6 w-6 stroke-current">
-                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                d="M4 6h16M4 12h16M4 18h16"></path>
-                        </svg>
-                    </label>
-                    <a class="btn btn-ghost text-xl" href="/"><img class="h-8 w-8" alt="" src="../assets/logo.png"></a>
-                </li>
-                <hr class="text-secondary pb-3" />
-                <li v-for="link in links" :key="link.name">
-                    <RouterLink class="py-2 text-lg" :to="link.path" activeClass="underline">{{ link.name }}</RouterLink>
-                </li>
-            </ul>
-        </div>
+    <div class="grid min-h-svh grid-rows-[auto_1fr_auto]">
+        <TheHeader />
+        <main>
+            <TheBreadcrumbs v-if="breadcrumbs" :items="breadcrumbs" />
+            <slot />
+        </main>
+        <TheFooter />
     </div>
 </template>
 <script setup lang="ts">
 import TheHeader from '../components/TheHeader.vue'
 import TheFooter from '../components/TheFooter.vue'
 import TheBreadcrumbs from '../components/TheBreadcrumbs.vue';
-import { useNavigationLinks } from '../composables/useNavigationLinks';
 
 defineProps<{
     breadcrumbs?: {
@@ -43,6 +19,4 @@ defineProps<{
         href: string
     }[]
 }>()
-
-const { links } = useNavigationLinks();
 </script>


### PR DESCRIPTION
Replace anchor tags with RouterLink in TheBreadcrumbs for proper routing.
Remove sidebar drawer from LayoutBasic and implement it in App.vue to centralize
navigation and improve layout consistency. Add drawer open state and close
handler in App.vue to manage sidebar visibility. Update sidebar styles and
interaction for better UX.