### PR TITLE
fix(skills): simplify skill sorting logic

### DIFF
--- a/src/pages/PageSkills.vue
+++ b/src/pages/PageSkills.vue
@@ -221,10 +221,7 @@ const skillsSorted = computed(() => {
         return skill.type === filterSkillType.value
     })
     return skillsFiltered.sort((a, b) => {
-        if (a.type === b.type) {
-            return a.name.localeCompare(b.name)
-        }
-        return a.type.localeCompare(b.type)
+        return a.name.localeCompare(b.name)
     })
 })
 </script>


### PR DESCRIPTION
Remove redundant type comparison in skill sorting function.  
Now skills are sorted only by name, improving readability and  
maintainability without affecting the filtered results.