### PR TITLE
fix(ui): force re-render of map point dialog on activePoint change

### DIFF
--- a/src/pages/PageWorldMap.vue
+++ b/src/pages/PageWorldMap.vue
@@ -24,7 +24,7 @@
 
                 <!-- Point Dialog -->
                 <dialog ref="mapPointDialog" class="modal modal-bottom sm:modal-middle">
-                    <div class="modal-box">
+                    <div class="modal-box" :key="activePoint ||  ''">
                         <form method="dialog">
                             <button class="btn btn-circle btn-ghost absolute right-4 top-4">✕</button>
                         </form>


### PR DESCRIPTION
Add a dynamic key binding to the modal-box div in the map point
dialog to ensure it re-renders whenever the activePoint changes.
This fixes potential stale state issues and improves dialog
responsiveness when switching between points.