### PR TITLE
fix(ui): add text-base class to email input in NewsletterForm

### DIFF
--- a/src/components/NewsletterForm.vue
+++ b/src/components/NewsletterForm.vue
@@ -10,7 +10,7 @@
             <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"></path>
           </g>
         </svg>
-        <input type="text" name="email" v-model="email" @blur="handleBlur"
+        <input class="text-base" type="text" name="email" v-model="email" @blur="handleBlur"
           placeholder="Hier deine E-Mail eingeben..." />
       </label>
       <div v-if="isEmailFieldTouched && errors.email" class="text-error">{{ errors.email }}</div>


### PR DESCRIPTION
Add the text-base class to the email input field to ensure consistent
font sizing and improve readability. This change addresses styling
inconsistencies and enhances the user experience when entering an email.