### PR TITLE
fix(router): avoid unused variable warnings in scrollBehavior

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -23,7 +23,7 @@ const router = createRouter({
             component: () => import('../pages/PageNotFound.vue'),
         },
     ],
-    scrollBehavior(to, from, savedPosition) {
+    scrollBehavior(_to, _from, savedPosition) {
         if (savedPosition) {
             return savedPosition
         } else {


### PR DESCRIPTION
Rename parameters 'to' and 'from' to '_to' and '_from' in the
scrollBehavior function to indicate they are intentionally unused.
This change prevents linter warnings and improves code clarity.