### PR TITLE
style: reduce default padding on key pages for better spacing

### DIFF
--- a/src/pages/PageCharacter.vue
+++ b/src/pages/PageCharacter.vue
@@ -1,8 +1,8 @@
 <template>
     <LayoutBasic :breadcrumbs="breadcrumbs">
-        <div class="m-auto grid h-full max-w-5xl p-8 text-left">
+        <div class="m-auto grid h-full max-w-5xl p-4 md:p-8 text-left">
             <div class="grid grid-cols-1 md:grid-cols-2">
-                <div class="flex flex-col justify-center gap-2 md:gap-4">
+                <div class="flex flex-col md:justify-center gap-2 md:gap-4">
                     <h1 class="text-4xl md:text-8xl font-nebulous-regular uppercase">{{ characterName }}</h1>
                     <p class="max-w-md">{{ character?.backstory }}</p>
                 </div>

--- a/src/pages/PageContact.vue
+++ b/src/pages/PageContact.vue
@@ -1,6 +1,6 @@
 <template>
     <LayoutBasic :breadcrumbs="breadcrumbs">
-        <div class="m-auto grid h-full max-w-6xl p-8 text-left">
+        <div class="m-auto grid h-full max-w-6xl p-4 md:p-8 text-left">
             <div class="flex flex-col gap-6">
                 <h1 class="text-4xl font-bold">Kontakt</h1>
                 <p>E-Mail: voxelcorelab@gmail.com</p>

--- a/src/pages/PageImprint.vue
+++ b/src/pages/PageImprint.vue
@@ -1,6 +1,6 @@
 <template>
     <LayoutBasic :breadcrumbs="breadcrumbs">
-        <div class="grid h-full max-w-6xl text-left m-auto p-8">
+        <div class="grid h-full max-w-6xl text-left m-auto p-4 md:p-8">
             <div class="flex flex-col gap-6">
                 <h1 class="text-4xl font-bold">Impressum</h1>
                 <h2 class="text-2xl font-bold">Voxel Core Lab GmbH</h2>

--- a/src/pages/PagePrivacyPolicy.vue
+++ b/src/pages/PagePrivacyPolicy.vue
@@ -1,6 +1,6 @@
 <template>
     <LayoutBasic :breadcrumbs="breadcrumbs">
-        <div class="m-auto grid h-full max-w-2xl p-8 text-left">
+        <div class="m-auto grid h-full max-w-2xl p-4 md:p-8 text-left">
             <div class="flex flex-col gap-6">
                 <h1 class="break-all text-2xl font-bold md:text-4xl">
                     Datenschutzerklärung


### PR DESCRIPTION
Adjust padding from p-8 to p-4 on mobile views across multiple pages
to improve content spacing and readability. Add responsive padding
(md:p-8) to maintain layout consistency on larger screens. Fix vertical
alignment on PageCharacter by changing flex justification to only apply
on medium screens and above. These changes enhance the user experience
by optimizing layout for different device sizes.