### PR TITLE
feat(characters): add characters page and refactor character data

### DIFF
--- a/src/composables/useCharacters.ts
+++ b/src/composables/useCharacters.ts
@@ -1,0 +1,37 @@
+import imgSelira from '../assets/characters/feather-girl.webp'
+import imgKael from '../assets/characters/bounty-hunter.webp'
+import imgVelmon from '../assets/characters/ghost.webp'
+import imgVareth from '../assets/characters/prince-of-death.webp'
+
+const characters: { id: string, name: string, backstory: string, image: string }[] = [
+    {
+        id: 'selira',
+        name: 'Selira',
+        backstory: 'Eine Assassinin aus dem Schattenzirkel. Hinterlässt silberne Dornen bei ihren Opfern.',
+        image: imgSelira
+    },
+    {
+        id: 'kael',
+        name: 'Kael',
+        backstory: 'Ein maskierter Kopfgeldjäger mit Jagdgewehr. Redet nicht. Verfehlt nie. Seine Liste ist persönlich und tödlich.',
+        image: imgKael
+    },
+    {
+        id: 'velmon',
+        name: 'Velmon',
+        backstory: 'Ein ruheloser Geist. Einst Sternenweise, jetzt Bote dunkler Vorzeichen. Flüstert Warnungen.',
+        image: imgVelmon
+    },
+    {
+        id: 'vareth',
+        name: 'Vareth',
+        backstory: 'Verfluchter Prinz eines toten Reiches. Halb lebendig, halb Tod. Jeder Schlag bringt ihn seinem göttlichen Erbe näher.',
+        image: imgVareth
+    }
+]
+
+export function useCharacters() {
+    return {
+        characters
+    }
+}

--- a/src/composables/useNavigationLinks.ts
+++ b/src/composables/useNavigationLinks.ts
@@ -2,7 +2,7 @@ export function useNavigationLinks() {
     const links = [
         { name: 'Home', path: '/' },
         { name: 'Weltkarte', path: '/world-map' },
-        { name: 'Spielverlauf', path: '/game-process' },
+        { name: 'Charaktere', path: '/characters' },
         { name: 'Fertigkeiten', path: '/skills' },
         { name: 'FAQ', path: '/faq' }
     ]

--- a/src/pages/PageCharacter.vue
+++ b/src/pages/PageCharacter.vue
@@ -17,10 +17,7 @@
 import LayoutBasic from '../layouts/LayoutBasic.vue'
 import { useRoute } from 'vue-router'
 
-import imgSelira from '../assets/characters/feather-girl.webp'
-import imgKael from '../assets/characters/bounty-hunter.webp'
-import imgVelmon from '../assets/characters/ghost.webp'
-import imgVareth from '../assets/characters/prince-of-death.webp'
+import { useCharacters } from '../composables/useCharacters'
 
 const route = useRoute()
 const characterId = route.params.characterId as string
@@ -28,33 +25,16 @@ const characterName = characterId.charAt(0).toUpperCase() + characterId.slice(1)
 
 const breadcrumbs = [
     {
+        text: 'Charaktere',
+        href: '/characters'
+    },
+    {
         text: characterName,
         href: `/characters/${characterId}`,
     }
 ]
 
-const characters: { id: string, backstory: string, image: string }[] = [
-    {
-        id: 'selira',
-        backstory: 'Eine Assassinin aus dem Schattenzirkel. Hinterlässt silberne Dornen bei ihren Opfern.',
-        image: imgSelira
-    },
-    {
-        id: 'kael',
-        backstory: 'Ein maskierter Kopfgeldjäger mit Jagdgewehr. Redet nicht. Verfehlt nie. Seine Liste ist persönlich und tödlich.',
-        image: imgKael
-    },
-    {
-        id: 'velmon',
-        backstory: 'Ein ruheloser Geist. Einst Sternenweise, jetzt Bote dunkler Vorzeichen. Flüstert Warnungen.',
-        image: imgVelmon
-    },
-    {
-        id: 'vareth',
-        backstory: 'Verfluchter Prinz eines toten Reiches. Halb lebendig, halb Tod. Jeder Schlag bringt ihn seinem göttlichen Erbe näher.',
-        image: imgVareth
-    }
-]
+const { characters } = useCharacters()
 
 const character = characters.find(character => character.id === characterId)
 </script>

--- a/src/pages/PageCharacters.vue
+++ b/src/pages/PageCharacters.vue
@@ -1,0 +1,17 @@
+<template>
+    <LayoutBasic :breadcrumbs="breadcrumbs">
+        <div class="max-w-7xl mx-auto p-4 md:p-8">
+            <h1 class="text-4xl md:text-8xl font-nebulous-regular uppercase">Charaktere</h1>
+        </div>
+    </LayoutBasic>
+</template>
+<script setup lang="ts">
+import LayoutBasic from '../layouts/LayoutBasic.vue'
+
+const breadcrumbs = [
+    {
+        text: 'Charaktere',
+        href: '/characters'
+    }
+]
+</script>

--- a/src/pages/PageHome.vue
+++ b/src/pages/PageHome.vue
@@ -88,18 +88,11 @@
 import 'vue3-carousel/carousel.css'
 import { Carousel, Slide, Pagination, Navigation } from 'vue3-carousel'
 import LayoutBasic from '../layouts/LayoutBasic.vue'
-import bountyHunter from '../assets/characters/bounty-hunter.webp'
-import featherAssassin from '../assets/characters/feather-girl.webp'
-import ghost from '../assets/characters/ghost.webp'
-import princeOfDeath from '../assets/characters/prince-of-death.webp'
 import NewsletterForm from '../components/NewsletterForm.vue'
+import { useCharacters } from '../composables/useCharacters'
 
-const characterSlides = [
-  { id: 1, name: 'Kael', image: bountyHunter },
-  { id: 2, name: 'Selira', image: featherAssassin },
-  { id: 3, name: 'Velmon', image: ghost },
-  { id: 4, name: 'Vareth', image: princeOfDeath }
-]
+const { characters } = useCharacters();
+const characterSlides = characters
 </script>
 <style>
 .world-map::after {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -9,6 +9,7 @@ const router = createRouter({
         { path: '/world-map', component: () => import('../pages/PageWorldMap.vue') },
         { path: '/game-process', component: () => import('../pages/PageGameProcess.vue') },
         { path: '/skills', component: () => import('../pages/PageSkills.vue') },
+        { path: '/characters', component: () => import('../pages/PageCharacters.vue') },
         { path: '/characters/:characterId', component: () => import('../pages/PageCharacter.vue') },
         { path: '/faq', component: () => import('../pages/PageFaq.vue') },
         { path: '/imprint', component: () => import('../pages/PageImprint.vue') },


### PR DESCRIPTION
Replace "Spielverlauf" navigation link with "Charaktere" to reflect new
characters section. Add a new PageCharacters.vue to display the characters
overview with breadcrumbs.

Refactor character data into a dedicated useCharacters composable to centralize
character info and images. Update PageCharacter.vue to use this composable
instead of hardcoded data and imports.

Add routing for the new characters page to enable navigation. These changes
improve maintainability and expand the app with a dedicated characters feature.