### PR TITLE
feat(characters): add character grid and uppercase slide links

### DIFF
--- a/src/pages/PageCharacters.vue
+++ b/src/pages/PageCharacters.vue
@@ -1,11 +1,24 @@
 <template>
     <LayoutBasic :breadcrumbs="breadcrumbs">
-        <div class="max-w-7xl mx-auto p-4 md:p-8">
+        <div class="max-w-7xl mx-auto p-4 md:p-8 grid gap-4">
             <h1 class="text-4xl md:text-8xl font-nebulous-regular uppercase">Charaktere</h1>
+            <div class="grid grid-cols-[repeat(2,_minmax(0px,_1fr))] md:grid-cols-[repeat(4,_minmax(0px,_1fr))] gap-4">
+                <RouterLink v-for="character in characters" :key="character.id" :to="`/characters/${character.id}`"
+                    class="bg-base-300 shadow-lg overflow-hidden flex flex-col items-center group">
+                    <div class="w-full overflow-hidden aspect-[0.75/1]">
+                        <img :src="character.image" :alt="character.name"
+                            class="w-full h-full object-cover transition-transform group-hover:scale-110 bg-linear-to-t from-neutral/90 to-neutral/60" />
+                    </div>
+                    <div class="p-4 w-full bg-secondary/50 group-hover:bg-secondary/75 transition-colors">
+                        <h2 class="text-2xl font-grest uppercase">{{ character.name }}</h2>
+                    </div>
+                </RouterLink>
+            </div>
         </div>
     </LayoutBasic>
 </template>
 <script setup lang="ts">
+import { useCharacters } from '../composables/useCharacters';
 import LayoutBasic from '../layouts/LayoutBasic.vue'
 
 const breadcrumbs = [
@@ -14,4 +27,6 @@ const breadcrumbs = [
         href: '/characters'
     }
 ]
+
+const { characters } = useCharacters()
 </script>

--- a/src/pages/PageHome.vue
+++ b/src/pages/PageHome.vue
@@ -69,7 +69,7 @@
             <div class="relative w-full h-full">
               <div
                 class="absolute w-full z-10 text-2xl md:text-5xl font-bold text-center text-base-content/80 flex items-center justify-center bottom-0 mb-10 md:mb-20">
-                <RouterLink :to="`/characters/${slide.name.toLowerCase()}`" class="relative px-2 py-1 md:px-3 md:py-2 font-grest border border-secondary bg-secondary/25 backdrop-blur-lg hover:bg-secondary/50 transition-colors">{{ slide.name }}</RouterLink>
+                <RouterLink :to="`/characters/${slide.name.toLowerCase()}`" class="relative px-2 py-1 md:px-3 md:py-2 font-grest uppercase border border-secondary bg-secondary/25 backdrop-blur-lg hover:bg-secondary/50 transition-colors">{{ slide.name }}</RouterLink>
               </div>
               <img :src="slide.image" class="object-contain h-full w-full" />
             </div>


### PR DESCRIPTION
Display characters in a responsive grid on the characters page with
hover effects for better visual engagement. Update slide links on the
home page to use uppercase text for improved consistency and emphasis.