### PR TITLE
style: add break-all to headings in PageCharacters.vue

### DIFF
--- a/src/pages/PageCharacters.vue
+++ b/src/pages/PageCharacters.vue
@@ -1,7 +1,7 @@
 <template>
     <LayoutBasic :breadcrumbs="breadcrumbs">
         <div class="max-w-7xl mx-auto p-4 md:p-8 grid gap-4">
-            <h1 class="text-4xl md:text-8xl font-nebulous-regular uppercase">Charaktere</h1>
+            <h1 class="text-4xl md:text-8xl font-nebulous-regular uppercase break-all">Charaktere</h1>
             <div class="grid grid-cols-[repeat(2,_minmax(0px,_1fr))] md:grid-cols-[repeat(4,_minmax(0px,_1fr))] gap-4">
                 <RouterLink v-for="character in characters" :key="character.id" :to="`/characters/${character.id}`"
                     class="bg-base-300 shadow-lg overflow-hidden flex flex-col items-center group">
@@ -10,7 +10,7 @@
                             class="w-full h-full object-cover transition-transform group-hover:scale-110 bg-linear-to-t from-neutral/90 to-neutral/60" />
                     </div>
                     <div class="p-4 w-full bg-secondary/50 group-hover:bg-secondary/75 transition-colors">
-                        <h2 class="text-2xl font-grest uppercase">{{ character.name }}</h2>
+                        <h2 class="text-2xl font-grest uppercase break-all">{{ character.name }}</h2>
                     </div>
                 </RouterLink>
             </div>


### PR DESCRIPTION
Add break-all CSS property to the main title and character names to
improve text wrapping and prevent overflow issues on smaller screens.
This change enhances readability and maintains layout integrity when
displaying long words or names.