### PR TITLE
fix(ui): constrain character image height on medium screens

### DIFF
--- a/src/pages/PageCharacter.vue
+++ b/src/pages/PageCharacter.vue
@@ -7,7 +7,7 @@
                     <p class="max-w-md">{{ character?.backstory }}</p>
                 </div>
                 <div class="flex justify-center items-center">
-                    <img :src="character?.image" class="h-full w-full max-h-[50svh] md:max-h-[calc(100svh-20rem)] object-contain" />
+                    <img :src="character?.image" class="h-full w-full max-h-[50svh] md:h-[50svh] md:max-h-[calc(100svh-20rem)] object-contain" />
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Adjust the character image styling to set a fixed height of 50svh on
medium screens, replacing the previous max-height constraint. This
ensures consistent image sizing and improves layout stability across
different viewport sizes.