### PR TITLE
feat(drawer): improve accessibility and keyboard navigation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,15 +1,13 @@
 <template>
       <div class="drawer">
-        <input id="my-drawer" type="checkbox" class="drawer-toggle" v-model="isDrawerOpen" />
-        <div class="drawer-content">
-          <RouterView :key="$route.path" />
-        </div>
+        <input id="my-drawer" type="checkbox" class="drawer-toggle" v-model="isDrawerOpen" inert="true" />
         <div class="drawer-side z-50">
             <label for="my-drawer" aria-label="close sidebar" class="drawer-overlay"></label>
             <ul class="menu bg-base-200 min-h-full w-80 p-0">
                 <!-- Sidebar content here -->
                 <li class="flex flex-row px-2 py-3">
-                    <label for="my-drawer" aria-label="close sidebar" class="btn btn-square btn-ghost">
+                    <label for="my-drawer" aria-label="close sidebar" class="btn btn-square btn-ghost" role="button" tabindex="0"
+                        @keydown.enter.prevent="() => closeDrawer()">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
                             class="inline-block h-6 w-6 stroke-current">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -24,6 +22,9 @@
                 </li>
             </ul>
         </div>
+        <div class="drawer-content">
+          <RouterView :key="$route.path" />
+        </div>
     </div>
 </template>
 <script setup lang="ts">
@@ -34,7 +35,8 @@ const { links } = useNavigationLinks();
 
 const isDrawerOpen = ref(false);
 
-const closeDrawer = () => {
-    isDrawerOpen.value = false;
-};
+function closeDrawer() {
+    const drawer = document.getElementById('my-drawer') as HTMLInputElement | null;
+    if (drawer) drawer.checked = false;
+}
 </script>

--- a/src/components/TheHeader.vue
+++ b/src/components/TheHeader.vue
@@ -3,7 +3,8 @@
         <div class="navbar bg-base-100 max-w-7xl mx-auto">
             <div class="navbar-start w-auto">
                 <div class="flex-none md:hidden">
-                    <label for="my-drawer" aria-label="open sidebar" class="btn btn-square btn-ghost">
+                    <label for="my-drawer" aria-label="open sidebar" class="btn btn-square btn-ghost" role="button" tabindex="0"
+                        @keydown.enter.prevent="openDrawer">
                         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
                             class="inline-block h-6 w-6 stroke-current">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -27,4 +28,9 @@
 import { useNavigationLinks } from '../composables/useNavigationLinks';
 
 const { links } = useNavigationLinks();
+
+function openDrawer() {
+    const drawer = document.getElementById('my-drawer') as HTMLInputElement | null;
+    if (drawer) drawer.checked = true;
+}
 </script>


### PR DESCRIPTION
Add keyboard support for opening and closing the sidebar drawer by handling
Enter key events on toggle buttons. Move drawer content structure to ensure
proper layering and add inert attribute to the hidden checkbox to improve
accessibility. Replace reactive state with direct DOM manipulation for drawer
toggle to simplify control logic.