### PR TITLE
fix(newsletter): add autocomplete attribute to email input

### DIFF
--- a/src/components/NewsletterForm.vue
+++ b/src/components/NewsletterForm.vue
@@ -11,7 +11,7 @@
           </g>
         </svg>
         <input class="text-base" type="text" name="email" v-model="email" @blur="handleBlur"
-          placeholder="Hier deine E-Mail eingeben..." />
+          placeholder="Hier deine E-Mail eingeben..." autocomplete="email" />
       </label>
       <div v-if="isEmailFieldTouched && errors.email" class="text-error">{{ errors.email }}</div>
 


### PR DESCRIPTION
Add autocomplete="email" to the email input field in the newsletter
form to improve user experience by enabling browser autofill for email
addresses. This change helps users fill out the form faster and reduces
input errors.