### PR TITLE
feat(i18n): translate german UI text to English

### DIFF
--- a/src/components/NewsletterForm.vue
+++ b/src/components/NewsletterForm.vue
@@ -1,10 +1,10 @@
 <template>
   <form @submit="onSubmit">
     <fieldset class="fieldset bg-base-100 rounded-box p-4 mt-4 shadow-lg border border-secondary/40 w-full md:w-xs">
-      <legend class="fieldset-legend">Was ist deine E-Mail?</legend>
+      <legend class="fieldset-legend">What is your E-Mail?</legend>
       <label class="input w-full floating-label"
         :class="{ 'input-error': isEmailFieldTouched && errors.email, 'input-success': isEmailFieldTouched && isEmailFieldValid }">
-        <span>Deine E-Mail</span>
+        <span>Your Email</span>
         <svg class="h-[1em] opacity-50" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
           <g stroke-linejoin="round" stroke-linecap="round" stroke-width="2.5" fill="none" stroke="currentColor">
             <rect width="20" height="16" x="2" y="4" rx="2"></rect>
@@ -12,13 +12,13 @@
           </g>
         </svg>
         <input class="text-base" type="text" name="email" v-model="email" @blur="handleBlur"
-          placeholder="Hier deine E-Mail eingeben..." autocomplete="email" />
+          placeholder="Enter your email..." autocomplete="email" />
       </label>
       <div v-if="isEmailFieldTouched && errors.email" class="text-error" role="alert" aria-live="assertive">
         {{ errors.email }}
       </div>
 
-      <button class="btn btn-secondary mt-4">Beim Newsletter anmelden</button>
+      <button class="btn btn-secondary mt-4">Subscribe to Newsletter</button>
     </fieldset>
   </form>
 
@@ -27,8 +27,8 @@
       <form method="dialog">
         <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
       </form>
-      <h3 class="text-lg font-nebulous-regular md:text-2xl">Beim Newsletter angemeldet</h3>
-      <p class="py-4">Du hast dich erfolgreich beim Newsletter angemeldet!</p>
+      <h3 class="text-lg font-nebulous-regular md:text-2xl">Subscribed to Newsletter</h3>
+      <p class="py-4">You have successfully subscribed to the newsletter!</p>
       <img alt="" src="../assets/adler.webp" class="h-40 w-40 mx-auto mt-4" />
       <div class="modal-action">
         <form method="dialog">
@@ -54,8 +54,8 @@ const newsletterSuccessModal = ref<HTMLDialogElement | null>(null);
 const validationSchema = toTypedSchema(
   zod.object({
     email: zod.string({
-      required_error: 'Eine valide E-Mail eingeben: beispiel@mail.com'
-    }).nonempty('Eine valide E-Mail eingeben: beispiel@mail.com').email({ message: 'Eine valide E-Mail eingeben: beispiel@mail.com' }),
+      required_error: 'Enter a valid E-Mail: example@mail.com'
+    }).nonempty('Enter a valid E-Mail: example@mail.com').email({ message: 'Enter a valid E-Mail: example@mail.com' }),
   }).required()
 );
 const { handleSubmit, errors, validate } = useForm({

--- a/src/components/TheFooter.vue
+++ b/src/components/TheFooter.vue
@@ -40,8 +40,8 @@
 </template>
 <script setup lang="ts">
 const links = [
-    { name: 'Impressum', path: '/imprint' },
-    { name: 'Kontakt', path: '/contact' },
-    { name: 'Datenschutzerklärung', path: '/privacy-policy' }
+    { name: 'Imprint', path: '/imprint' },
+    { name: 'Contact', path: '/contact' },
+    { name: 'Privacy Policy', path: '/privacy-policy' }
 ]
 </script>

--- a/src/composables/useCharacters.ts
+++ b/src/composables/useCharacters.ts
@@ -7,28 +7,29 @@ const characters: { id: string, name: string, backstory: string, image: string }
     {
         id: 'selira',
         name: 'Selira',
-        backstory: 'Eine Assassinin aus dem Schattenzirkel. Hinterlässt silberne Dornen bei ihren Opfern.',
+        backstory: 'An assassin from the Shadow Circle. Leaves silver thorns with her victims.',
         image: imgSelira
     },
     {
         id: 'kael',
         name: 'Kael',
-        backstory: 'Ein maskierter Kopfgeldjäger mit Jagdgewehr. Redet nicht. Verfehlt nie. Seine Liste ist persönlich und tödlich.',
+        backstory: 'A masked bounty hunter with a hunting rifle. Speaks not. Never misses. His list is personal and deadly.',
         image: imgKael
     },
     {
         id: 'velmon',
         name: 'Velmon',
-        backstory: 'Ein ruheloser Geist. Einst Sternenweise, jetzt Bote dunkler Vorzeichen. Flüstert Warnungen.',
+        backstory: 'A restless spirit. Once a Sage of the Stars, now a harbinger of dark omens. Whispers warnings.',
         image: imgVelmon
     },
     {
         id: 'vareth',
         name: 'Vareth',
-        backstory: 'Verfluchter Prinz eines toten Reiches. Halb lebendig, halb Tod. Jeder Schlag bringt ihn seinem göttlichen Erbe näher.',
+        backstory: 'Cursed prince of a dead kingdom. Half alive, half death. Each strike brings him closer to his divine heritage.',
         image: imgVareth
     }
 ]
+
 
 export function useCharacters() {
     return {

--- a/src/composables/useNavigationLinks.ts
+++ b/src/composables/useNavigationLinks.ts
@@ -1,9 +1,9 @@
 export function useNavigationLinks() {
     const links = [
         { name: 'Home', path: '/' },
-        { name: 'Weltkarte', path: '/world-map' },
-        { name: 'Charaktere', path: '/characters' },
-        { name: 'Fertigkeiten', path: '/skills' },
+        { name: 'World Map', path: '/world-map' },
+        { name: 'Characters', path: '/characters' },
+        { name: 'Skills', path: '/skills' },
         { name: 'FAQ', path: '/faq' }
     ]
     return {

--- a/src/pages/PageCharacter.vue
+++ b/src/pages/PageCharacter.vue
@@ -25,7 +25,7 @@ const characterName = characterId.charAt(0).toUpperCase() + characterId.slice(1)
 
 const breadcrumbs = [
     {
-        text: 'Charaktere',
+        text: 'Characters',
         href: '/characters'
     },
     {

--- a/src/pages/PageCharacters.vue
+++ b/src/pages/PageCharacters.vue
@@ -1,7 +1,7 @@
 <template>
     <LayoutBasic :breadcrumbs="breadcrumbs">
         <div class="max-w-7xl mx-auto p-4 md:p-8 grid gap-4">
-            <h1 class="text-4xl md:text-8xl font-nebulous-regular uppercase break-all">Charaktere</h1>
+            <h1 class="text-4xl md:text-8xl font-nebulous-regular uppercase break-all">Characters</h1>
             <div class="grid grid-cols-[repeat(2,_minmax(0px,_1fr))] md:grid-cols-[repeat(4,_minmax(0px,_1fr))] gap-4">
                 <RouterLink v-for="character in characters" :key="character.id" :to="`/characters/${character.id}`"
                     class="bg-base-300 shadow-lg overflow-hidden flex flex-col items-center group">
@@ -23,7 +23,7 @@ import LayoutBasic from '../layouts/LayoutBasic.vue'
 
 const breadcrumbs = [
     {
-        text: 'Charaktere',
+        text: 'Characters',
         href: '/characters'
     }
 ]

--- a/src/pages/PageContact.vue
+++ b/src/pages/PageContact.vue
@@ -2,7 +2,7 @@
     <LayoutBasic :breadcrumbs="breadcrumbs">
         <div class="m-auto grid h-full max-w-6xl p-4 md:p-8 text-left">
             <div class="flex flex-col gap-6">
-                <h1 class="text-4xl font-bold">Kontakt</h1>
+                <h1 class="text-4xl font-bold">Contact</h1>
                 <p>E-Mail: voxelcorelab@gmail.com</p>
             </div>
         </div>
@@ -13,7 +13,7 @@ import LayoutBasic from '../layouts/LayoutBasic.vue'
 
 const breadcrumbs = [
     {
-        text: 'Kontakt',
+        text: 'Contact',
         href: '/contact'
     }
 ]

--- a/src/pages/PageFaq.vue
+++ b/src/pages/PageFaq.vue
@@ -2,7 +2,7 @@
     <LayoutBasic :breadcrumbs="breadcrumbs">
         <div class="max-w-2xl mx-auto p-4 md:p-8">
             <h1 class="text-4xl md:text-8xl font-nebulous-regular uppercase">FAQ</h1>
-            <p class="text-sm">Hier findest du die häufigsten Fragen und Antworten zu unserem Spiel.</p>
+            <p class="text-sm">Here you can find the most frequently asked questions and answers about the game.</p>
             <div class="mt-4 grid gap-2">
                 <div v-for="(faq, index) in faqs" :key="index" tabindex="0" class="collapse collapse-arrow bg-base-100 border-secondary/40 border">
                     <div class="collapse-title font-semibold">{{ faq.question }}</div>
@@ -26,32 +26,33 @@ const breadcrumbs = [
 
 const faqs: { question: string, answer: string }[] = [
     {
-        question: 'Was für ein Genre ist das Spiel?',
-        answer: 'Das Spiel ist ein Co-op Online Arena Survival Game.'
+        question: 'What genre is the game?',
+        answer: 'The game is a co-op pve and pvp online arena survival game.'
     },
     {
-        question: 'Wie viele Spieler können mitspielen?',
-        answer: 'Das Spiel ist für 1-5 Spieler ausgelegt.'
+        question: 'How many players can join?',
+        answer: 'The PvE mode is designed for 1–5 players. The PvP mode is designed for 2–12 players.'
     },
     {
-        question: 'Wie lange dauert eine Runde?',
-        answer: 'Eine Runde dauert etwa 30 Minuten'
+        question: 'How long does a round last?',
+        answer: 'A round lasts about 30 minutes.'
     },
     {
-        question: 'Wie viele Karten gibt es?',
-        answer: 'Es gibt 3 verschiedene Karten'
+        question: 'How many maps are there?',
+        answer: 'There are 3 different maps planned for the start.'
     },
     {
-        question: 'Welche Steuerung wird in Shadow Infection verwendet?',
-        answer: 'Das Spiel wird mit Maus und Tastatur gespielt.'
+        question: 'What controls are used in Shadow Infection?',
+        answer: 'The game is played with mouse and keyboard.'
     },
     {
-        question: 'Weleches Betriebssystem wird benötigt?',
-        answer: 'Das Spiel läuft auf Windows 11'
+        question: 'Which operating system is required?',
+        answer: 'The game runs on Windows, Linux and MacOS.'
     },
     {
-        question: 'Wann wird das Spiel veröffentlicht?',
-        answer: 'Das Spiel wird voraussichtlich im Jahr 2026 veröffentlicht.'
+        question: 'When will the game be released?',
+        answer: 'The game is expected to be released in 2026.'
     }
 ]
+
 </script>

--- a/src/pages/PageHome.vue
+++ b/src/pages/PageHome.vue
@@ -11,14 +11,14 @@
             <div>
               <p
                 class="text-[clamp(var(--text-4xl),5vw,var(--text-6xl))] text-4xl lg:text-6xl font-nebulous-regular text-center">
-                Entdecke jetzt die Spielwelt!</p>
+                Discover the game world now!</p>
             </div>
             <div class="self-center">
               <a href="/world-map"
                 class="btn btn-secondary btn-md lg:btn-xl inline-flex items-center gap-2 relative overflow-hidden group scale-100 hover:scale-103 transition-transform duration-300">
                 <span
                   class="absolute inset-0 bg-gradient-to-r from-purple-500 to-indigo-500 transform scale-x-0 group-hover:scale-x-100 transition-transform duration-300 origin-left"></span>
-                <span class="relative z-10">Zur Weltkarte</span>
+                <span class="relative z-10">To the World Map</span>
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 relative z-10" fill="none" viewBox="0 0 24 24"
                   stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />
@@ -35,10 +35,7 @@
       <div class="max-w-6xl mx-auto py-4 px-4 grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-16">
         <div>
           <h2 class="text-4xl md:text-8xl pb-4 font-nebulous-regular uppercase sticky z-10">Newsletter</h2>
-          <p class="max-w-lg">Erhalte News zum Spiel direkt in dein Postfach. Wir informieren dich über Updates,
-            Patches,
-            den
-            Start der Beta und die Veröffentlichung des Spieles.</p>
+          <p class="max-w-lg">Get news about the game straight to your inbox. You will be the first to know about updates, patches, and the game’s release.</p>
           <NewsletterForm />
         </div>
         <div class="flex justify-center items-center z-0">
@@ -50,8 +47,8 @@
       <div class="max-w-6xl mx-auto py-4 px-4 grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-16">
         <div>
           <h2 class="text-4xl md:text-8xl pb-4 break-all font-nebulous-regular uppercase">Release</h2>
-          <p class="max-w-lg">Die Beta-Phase ist voraussichtlich Ende 2025</p>
-          <p class="max-w-lg">Die offizielle Veröffentlichung ist für das Jahr 2026 geplant.</p>
+          <p class="max-w-lg">The game is currently in development.</p>
+          <p class="max-w-lg">Sign up to the Newsletter to receive updates about the release.</p>
         </div>
         <div class="flex justify-center items-center">
           <img alt="" class="h-40" src="../assets/meilenstein.webp" />

--- a/src/pages/PageImprint.vue
+++ b/src/pages/PageImprint.vue
@@ -2,7 +2,7 @@
     <LayoutBasic :breadcrumbs="breadcrumbs">
         <div class="grid h-full max-w-6xl text-left m-auto p-4 md:p-8">
             <div class="flex flex-col gap-6">
-                <h1 class="text-4xl font-bold">Impressum</h1>
+                <h1 class="text-4xl font-bold">Imprint</h1>
                 <h2 class="text-2xl font-bold">Voxel Core Lab GmbH</h2>
                 <p>Sitz: Bern</p>
                 <p>

--- a/src/pages/PageNotFound.vue
+++ b/src/pages/PageNotFound.vue
@@ -10,7 +10,7 @@
           </h1>
           <div class="max-w-sm lg:max-w-md xl:max-w-2xl">
             <a href="/" class="link-hover link font-bold lg:text-xl xl:text-2xl"
-              >Zurück zur Startseite</a
+              >Back to Home</a
             >
           </div>
         </div>

--- a/src/pages/PageSkills.vue
+++ b/src/pages/PageSkills.vue
@@ -1,14 +1,14 @@
 <template>
     <LayoutBasic :breadcrumbs="breadcrumbs">
         <div class="max-w-7xl mx-auto p-4 md:p-8">
-            <h1 class="text-4xl md:text-8xl font-nebulous-regular uppercase">Fertigkeiten</h1>
+            <h1 class="text-4xl md:text-8xl font-nebulous-regular uppercase">Skills</h1>
             <div class="filter mt-2">
                 <input v-model="filterSkillType" class="btn filter-reset" value="" type="radio" name="skillType" aria-label="All"/>
                 <input v-model="filterSkillType" class="btn" type="radio" value="Passive" name="skillType" aria-label="Passive"/>
                 <input v-model="filterSkillType" class="btn" type="radio" value="Normal" name="skillType" aria-label="Normal"/>
                 <input v-model="filterSkillType" class="btn" type="radio" value="Ultimate" name="skillType" aria-label="Ultimate"/>
             </div>
-            <div class="text-lg mt-4">Sichtbar {{ skillsSorted.length }} von {{ skills.length }}</div>
+            <div class="text-lg mt-4">Visible {{ skillsSorted.length }} of {{ skills.length }}</div>
             <div class="mt-2 grid gap-4 gird-cols-1 md:grid-cols-2 lg:grid-cols-3">
                 <div v-for="skill in skillsSorted" :key="skill.name"
                     class="bg-base-100 border-secondary/40 border @container">
@@ -66,150 +66,151 @@ const breadcrumbs = [
 
 const skills: { name: string, description: string, image: string, cooldown: number, maxCharges: number, type: 'Passive' | 'Normal' | 'Ultimate' }[] = [
     {
-        name: 'Schnelligkeit',
-        description: 'Du bewegst dich 3 Sekunden lang 50% schneller.',
+        name: 'Swiftness',
+        description: 'You move 50% faster for 3 seconds.',
         image: imgSkillSwiftness,
         cooldown: 30,
         maxCharges: 2,
         type: 'Normal'
     },
     {
-        name: 'Geistiger Segen',
-        description: 'Heilt für 60. Du opfert 20% deiner Lebenspunkte. Du opferst keine Lebenspunkte, wenn du dich in Hörweite eines Geists befindest.',
+        name: 'Spiritual Blessing',
+        description: 'Heals for 60. You sacrifice 20% of your health. You do not sacrifice health if you are within earshot of a spirit.',
         image: imgSpiritBlessing,
         cooldown: 30,
         maxCharges: 1,
         type: 'Normal'
     },
     {
-        name: 'Schattenform',
-        description: 'Du bewegst dich 15 Sekunden lang 10% schneller und erleidest nur 50% des eingehenden Schadens.',
+        name: 'Shadow Form',
+        description: 'You move 10% faster for 15 seconds and take only 50% of incoming damage.',
         image: imgShadowForm,
         cooldown: 70,
         maxCharges: 1,
         type: 'Ultimate'
     },
     {
-        name: 'Gift anwenden',
-        description: 'Deine Fernkampfangriffe vergiften den Gegner 5 Sekunden lang und verursachen 2 Schaden pro Sekunde.',
+        name: 'Apply Poison',
+        description: 'Your ranged attacks poison the target for 5 seconds, dealing 2 damage per second.',
         image: imgPoision,
         cooldown: 0,
         maxCharges: 0,
         type: 'Passive'
     },
     {
-        name: 'Schildwache',
-        description: 'Schildet einen Spieler für 25.',
+        name: 'Sentinel',
+        description: 'Shields a player for 25.',
         image: imgShieldGuard,
         cooldown: 30,
         maxCharges: 1,
         type: 'Normal'
     },
     {
-        name: 'Schützende Hände',
-        description: 'Reduziert 20 Sekunden lang den eingehenden Schaden um 3.',
+        name: 'Protective Hands',
+        description: 'Reduces incoming damage by 3 for 20 seconds.',
         image: imgShieldingHands,
         cooldown: 40,
         maxCharges: 2,
         type: 'Normal'
     },
     {
-        name: 'Heilendes Blatt',
-        description: 'Heilt das Ziel über 9 Sekunden lang alle 3 Sekunden um 15 Lebenspunkte.',
+        name: 'Healing Leaf',
+        description: 'Heals the target for 15 health every 3 seconds over 9 seconds.',
         image: imgHealingLeaf,
         cooldown: 30,
         maxCharges: 2,
         type: 'Normal'
     },
     {
-        name: 'Auferstehung',
-        description: 'Belebt einen verbündeten Spieler mit voller Gesundheit wieder.',
+        name: 'Resurrection',
+        description: 'Revives an allied player with full health.',
         image: imgResurrection,
         cooldown: 120,
         maxCharges: 1,
         type: 'Ultimate'
     },
     {
-        name: 'Rune der Heilung',
-        description: 'Heilt 30 Lebenspunkte. Heilt 60 weitere Lebenspunkte über 5 Sekunden, wenn das Ziel unter 50% Gesundheit hat.',
+        name: 'Rune of Healing',
+        description: 'Heals 30 health. Heals an additional 60 health over 5 seconds if the target is below 50% health.',
         image: imgRuneOfHealing,
         cooldown: 60,
         maxCharges: 1,
         type: 'Ultimate'
     },
     {
-        name: 'Lakai der Toten',
-        description: 'Beschwört einen untoten Lakai aus einer Leiche in der Nähe, der an deiner Seite kämpft.',
+        name: 'Minion of the Dead',
+        description: 'Summons an undead minion from a nearby corpse to fight by your side.',
         image: imgMinionOfTheDead,
         cooldown: 40,
         maxCharges: 1,
         type: 'Normal'
     },
     {
-        name: 'Segen des Löwen',
-        description: 'Gewinne jede Sekunde, die du dich bewegst, 1 Schild bis zu 20.',
+        name: 'Blessing of the Lion',
+        description: 'Gain 1 shield per second while moving, up to 20.',
         image: imgBlessingOfTheLion,
         cooldown: 0,
         maxCharges: 0,
         type: 'Passive'
     },
     {
-        name: 'Bewahrung',
-        description: 'Beschwört einen Geist für 60 Sekunden, der Verbündete in der Nähe alle 10 Sekunden über 5 Sekunden um 20 Lebenspunkte heilt.',
+        name: 'Preservation',
+        description: 'Summons a spirit for 60 seconds that heals nearby allies for 20 health over 5 seconds every 10 seconds.',
         image: imgPreservation,
         cooldown: 70,
         maxCharges: 1,
         type: 'Ultimate'
     },
     {
-        name: 'Blutgesang',
-        description: 'Ruft einen Geist herbei, der Gegner in der Nähe angreift.',
+        name: 'Bloodsong',
+        description: 'Summons a spirit that attacks nearby enemies.',
         image: imgBloodsong,
         cooldown: 60,
         maxCharges: 1,
         type: 'Normal'
     },
     {
-        name: 'Essenz-Schlag',
-        description: 'Wirke einen Blitz, der 30 Schaden verursacht.',
+        name: 'Essence Strike',
+        description: 'Casts a lightning bolt dealing 30 damage.',
         image: imgEssenceStrike,
         cooldown: 35,
         maxCharges: 1,
         type: 'Normal'
     },
     {
-        name: 'Seelenheilung',
-        description: 'Heilt für 40. Entfernt einen Zustand für jeden Geist in Hörweite.',
+        name: 'Soul Mend',
+        description: 'Heals for 40. Removes one condition for each spirit within earshot.',
         image: imgSouldMend,
         cooldown: 40,
         maxCharges: 1,
         type: 'Normal'
     },
     {
-        name: 'Barriere',
-        description: 'Platziert eine solide Wand über 40 Sekunden.',
+        name: 'Barrier',
+        description: 'Places a solid wall for 40 seconds.',
         image: imgBarrier,
         cooldown: 60,
         maxCharges: 1,
         type: 'Normal'
     },
     {
-        name: 'Frostkegel',
-        description: 'Verlangsamt Gegner in einem Kegel vor dir 5 Sekunden lang um 50% und fügt ihnen 20 Schaden zu.',
+        name: 'Cone of Cold',
+        description: 'Slows enemies in a cone in front of you by 50% for 5 seconds and deals 20 damage.',
         image: imgConeOfCold,
         cooldown: 40,
         maxCharges: 1,
         type: 'Normal'
     },
     {
-        name: 'Eissprengung',
-        description: 'Feuert einen langen Strahl ab, der allen getroffenen Gegnern 50 Schaden zufügt.',
+        name: 'Ice Blast',
+        description: 'Fires a long beam dealing 50 damage to all enemies hit.',
         image: imgIceBlast,
         cooldown: 45,
         maxCharges: 1,
         type: 'Normal'
     }
 ]
+
 
 const filterSkillType = ref('')
 

--- a/src/pages/PageWorldMap.vue
+++ b/src/pages/PageWorldMap.vue
@@ -30,7 +30,7 @@
                         <div class="max-h-[60vh] overflow-y-auto pb-6 px-6" :key="activePoint || ''">
                             <img class="w-full aspect-video h-auto rounded-lg mt-4 bg-base-300 skeleton"
                                 :src="getActivePoint?.image" alt="" />
-                            <h2 class="text-lg font-semibold mt-4">Monster</h2>
+                            <h2 class="text-lg font-semibold mt-4">Monsters</h2>
                             <div class="grid grid-cols-4 gap-2 mt-2">
                                 <div v-for="(monster, index) in getActivePoint?.monsters" :key="index"
                                     class="bg-base-100/60 rounded-lg">
@@ -38,7 +38,7 @@
                                         alt="" />
                                 </div>
                             </div>
-                            <h2 class="text-lg font-semibold mt-4">Schwierigkeit</h2>
+                            <h2 class="text-lg font-semibold mt-4">Difficulty</h2>
                             <div class="flex items-center gap-2 pt-2">
                                 <div v-for="i in 3" :key="i" class="w-8 h-8 rounded-full" :class="{
                                     'text-red-600': i <= (getActivePoint?.difficulty ?? 0),
@@ -87,7 +87,7 @@
                                     </svg>
                                 </div>
                             </div>
-                            <h2 class="text-lg font-semibold mt-4">Geschichte</h2>
+                            <h2 class="text-lg font-semibold mt-4">Lore</h2>
                             <p class="pt-2">{{ getActivePoint?.description }}</p>
                         </div>
                     </div>
@@ -154,36 +154,36 @@ const openPoint = (pointId: number) => {
 
 const breadcrumbs = [
     {
-        text: 'Weltkarte',
+        text: 'World Map',
         href: '/world-map'
     }
 ]
 
 const points: { id: number, x: number, y: number, name: string, description: string, image: string, monsters: string[], difficulty: number, letter: string }[] = [
     {
-        id: 1, x: 78, y: 52, name: 'Das verderbte Mausoleum', image: imgMausoleum,
-        description: 'Tief im Herzen eines verfluchten Sumpfes liegt das verderbte Mausoleum, einst Ruhestätte eines vergessenen Schattenkults. Dort brach vor Jahrhunderten die Schattenseuche aus. Ein dunkler Fluch, der Fleisch, Geist und Licht gleichermassen zerfrisst. Noch heute wabern schwarze Nebel durch die zerfallenen Hallen, und aus den Gräbern flüstern Stimmen, die längst tot sein sollten.',
+        id: 1, x: 78, y: 52, name: 'The Corrupted Mausoleum', image: imgMausoleum,
+        description: 'Deep in the heart of a cursed swamp lies the Corrupted Mausoleum, once the resting place of a forgotten shadow cult. Centuries ago, the Shadow Plague broke out there. A dark curse that devours flesh, spirit, and light alike. Even today, black mists swirl through the crumbling halls, and voices whisper from graves that should long be silent.',
         monsters: [imgMausoleumMonster1, imgMausoleumMonster2, imgMausoleumMonster3, imgMausoleumMonster4, imgMausoleumMonster5, imgMausoleumMonster6],
         difficulty: 3,
         letter: 'A'
     },
     {
         id: 2, x: 58.5, y: 55, name: 'Elderglade', image: imgElderglade,
-        description: 'Versteckt im leuchtenden Blauen Kristallwald erhebt sich Elderglade, eine uralte Stadt, in der Naturmagie in jedem Blatt pulsiert. Ihre Bewohner bewahren das Gleichgewicht zwischen den lebenden Wäldern und den arkanen Strömen unter der Erde. Es heisst, dass Elderglade selbst atmet und nur jene willkommen heisst, die sich den Prüfungen des Waldes zu stellen.',
+        description: 'Hidden within the glowing Blue Crystal Forest stands Elderglade, an ancient city where nature magic pulses in every leaf. Its inhabitants maintain the balance between the living forests and the arcane currents beneath the earth. It is said that Elderglade itself breathes and only welcomes those who dare to face the trials of the forest.',
         monsters: [imgEldergladeMonster1, imgEldergladeMonster2, imgEldergladeMonster3, imgEldergladeMonster4],
         difficulty: 1,
         letter: 'B'
     },
     {
-        id: 3, x: 30, y: 10, name: 'Die weissen Gräber', image: imgWhitegraves,
-        description: 'Weit im gefrorenen Norden, wo selbst der Wind zu flüstern scheint, liegen die Weissen Gräber. Uralte Hügel aus ewigem Schnee, die einst gefallenen Königen und vergessenen Helden gehörten. Doch unter dem Eis regen sich Schatten, und die Geister der Toten wandeln unruhig, gefesselt an ein uraltes, gebrochenes Schwurband. Kein Lebender bleibt dort lange. Denn die Kälte zehrt nicht nur am Körper, sondern auch an der Seele.',
+        id: 3, x: 30, y: 10, name: 'The White Graves', image: imgWhitegraves,
+        description: 'Far in the frozen North, where even the wind seems to whisper, lie the White Graves. Ancient mounds of eternal snow, once belonging to fallen kings and forgotten heroes. Yet beneath the ice, shadows stir, and the spirits of the dead wander restlessly, bound to an ancient, broken oath. No living soul lingers there for long. For the cold preys not only on the body, but on the soul as well.',
         monsters: [imgWhitegravesMonster1, imgWhitegravesMonster2, imgWhitegravesMonster3, imgWhitegravesMonster4, imgWhitegravesMonster5],
         difficulty: 3,
         letter: 'C'
     },
     {
-        id: 4, x: 38, y: 86, name: 'Düsterhafen', image: imgDusterhafen,
-        description: 'Düsterhafen liegt verborgen in einer immerwährenden Nebelbucht, wo die Sonne nur als blasses Flackern durch den grauen Dunst dringt. Einst ein sicherer Handelsposten, wurde die Stadt von verfluchten Piraten übernommen, die ihre Seelen für ewige Beute dem Tiefenmeer geopfert haben.',
+        id: 4, x: 38, y: 86, name: 'Black Harbor', image: imgDusterhafen,
+        description: 'Black Harbor lies hidden within a bay of everlasting mist, where the sun pierces the gray haze only as a pale flicker. Once a secure trading post, the city was seized by cursed pirates who sacrificed their souls to the Deep Sea in exchange for eternal plunder. Now, the harbor is a labyrinth of decaying docks and haunted taverns, where the restless dead seek to reclaim what was lost to the depths.',
         monsters: [imgDusterhafenMonster1, imgDusterhafenMonster2, imgDusterhafenMonster3, imgDusterhafenMonster4, imgDusterhafenMonster5],
         difficulty: 2,
         letter: 'D'


### PR DESCRIPTION
Update multiple pages and navigation links to use English
copy for the public-facing UI and FAQs. Change breadcrumb and
heading labels from German to English (Characters, World Map,
Skills, Imprint, Back to Home), and replace the FAQ content with
English questions and answers that clarify game modes, player
counts, duration, maps, controls, OS support, and release
timeline. This prepares the site for English-speaking users and
improves clarity of information.